### PR TITLE
Fix nullptr references in wifi_manager and http_server

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -559,7 +559,8 @@ void http_server_netconn_serve(struct netconn *conn) {
 		char *host = http_server_get_header(save_ptr, "Host: ", &lenH);
 		/* determine if Host is from the STA IP address */
 		wifi_manager_lock_sta_ip_string(portMAX_DELAY);
-		bool access_from_sta_ip = lenH > 0?strstr(host, wifi_manager_get_sta_ip_string()):false;
+		char *ipStr = wifi_manager_get_sta_ip_string();
+		bool access_from_sta_ip = NULL == ipStr || (lenH > 0 && strstr(host, ipStr));
 		wifi_manager_unlock_sta_ip_string();
 
 		if (lenH > 0 && !strstr(host, DEFAULT_AP_IP) && !access_from_sta_ip) {

--- a/src/wifi_manager.c
+++ b/src/wifi_manager.c
@@ -406,7 +406,9 @@ bool wifi_manager_lock_sta_ip_string(TickType_t xTicksToWait){
 }
 
 void wifi_manager_unlock_sta_ip_string(){
-	xSemaphoreGive( wifi_manager_sta_ip_mutex );
+	if(wifi_manager_sta_ip_mutex){
+		xSemaphoreGive( wifi_manager_sta_ip_mutex );
+	}
 }
 
 void wifi_manager_safe_update_sta_ip_string(uint32_t ip){


### PR DESCRIPTION
The http_server might be running and responding to requests over Ethernet while the wifi_manager itself is not (yet or anymore) in a proper up state. This causes two nullptr references in the captive portal functionality that checks if the requested IP matches the IP of the AP, which is not (yet or anymore) up.