### PR TITLE
Fix #314: Requesting status.json during network connection can cause software assert and device reboot

### DIFF
--- a/src/http_server_accept_and_handle_conn.c
+++ b/src/http_server_accept_and_handle_conn.c
@@ -837,6 +837,7 @@ http_server_netconn_resp(struct netconn* const p_conn, http_server_resp_t* const
             http_server_netconn_resp_504(p_conn, p_resp);
             return;
     }
+    LOG_ERR("Unsupported HTTP response code: %u", (printf_uint_t)p_resp->http_resp_code);
     assert(0);
     http_server_netconn_resp_503(p_conn, p_resp);
 }

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -163,11 +163,7 @@ http_server_handle_req_get(
                .flag_access_from_lan = p_param->flag_access_from_lan,
         };
         const os_delta_ticks_t ticks_to_wait = pdMS_TO_TICKS(500U);
-        if (!json_network_info_do_const_action_with_timeout(&http_server_gen_resp_status_json, &params, ticks_to_wait))
-        {
-            LOG_ERR("GET /status.json: failed to get json, return HTTP error 503");
-            return http_server_resp_503();
-        }
+        json_network_info_do_const_action_with_timeout(&http_server_gen_resp_status_json, &params, ticks_to_wait);
         wifi_manager_cb_on_request_status_json();
         return http_resp;
     }

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -162,8 +162,12 @@ http_server_handle_req_get(
                .p_http_resp          = &http_resp,
                .flag_access_from_lan = p_param->flag_access_from_lan,
         };
-        const os_delta_ticks_t ticks_to_wait = 10U;
-        json_network_info_do_const_action_with_timeout(&http_server_gen_resp_status_json, &params, ticks_to_wait);
+        const os_delta_ticks_t ticks_to_wait = pdMS_TO_TICKS(500U);
+        if (!json_network_info_do_const_action_with_timeout(&http_server_gen_resp_status_json, &params, ticks_to_wait))
+        {
+            LOG_ERR("GET /status.json: failed to get json, return HTTP error 503");
+            return http_server_resp_503();
+        }
         wifi_manager_cb_on_request_status_json();
         return http_resp;
     }

--- a/src/json_network_info.c
+++ b/src/json_network_info.c
@@ -135,18 +135,20 @@ json_network_info_do_action_with_timeout_without_param(
     }
 }
 
-void
+bool
 json_network_info_do_const_action_with_timeout(
     json_network_info_do_const_action_callback_t cb_func,
     void* const                                  p_param,
     const os_delta_ticks_t                       ticks_to_wait)
 {
     const json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL != p_info)
+    if (NULL == p_info)
     {
-        cb_func(p_info, p_param);
-        json_network_info_unlock_const(&p_info);
+        return false;
     }
+    cb_func(p_info, p_param);
+    json_network_info_unlock_const(&p_info);
+    return true;
 }
 
 void

--- a/src/json_network_info.c
+++ b/src/json_network_info.c
@@ -101,11 +101,8 @@ json_network_info_do_action_with_timeout(
     const os_delta_ticks_t                 ticks_to_wait)
 {
     json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL != p_info)
-    {
-        cb_func(p_info, p_param);
-        json_network_info_unlock(&p_info);
-    }
+    cb_func(p_info, p_param);
+    json_network_info_unlock(&p_info);
 }
 
 void
@@ -115,11 +112,8 @@ json_network_info_do_action_with_timeout_with_const_param(
     const os_delta_ticks_t                                  ticks_to_wait)
 {
     json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL != p_info)
-    {
-        cb_func(p_info, p_param);
-        json_network_info_unlock(&p_info);
-    }
+    cb_func(p_info, p_param);
+    json_network_info_unlock(&p_info);
 }
 
 void
@@ -128,27 +122,19 @@ json_network_info_do_action_with_timeout_without_param(
     const os_delta_ticks_t                               ticks_to_wait)
 {
     json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL != p_info)
-    {
-        cb_func(p_info);
-        json_network_info_unlock(&p_info);
-    }
+    cb_func(p_info);
+    json_network_info_unlock(&p_info);
 }
 
-bool
+void
 json_network_info_do_const_action_with_timeout(
     json_network_info_do_const_action_callback_t cb_func,
     void* const                                  p_param,
     const os_delta_ticks_t                       ticks_to_wait)
 {
     const json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL == p_info)
-    {
-        return false;
-    }
     cb_func(p_info, p_param);
     json_network_info_unlock_const(&p_info);
-    return true;
 }
 
 void
@@ -158,11 +144,8 @@ json_network_info_do_const_action_with_timeout_with_const_param(
     const os_delta_ticks_t                                        ticks_to_wait)
 {
     const json_network_info_t* p_info = json_network_info_lock_with_timeout(ticks_to_wait);
-    if (NULL != p_info)
-    {
-        cb_func(p_info, p_param);
-        json_network_info_unlock_const(&p_info);
-    }
+    cb_func(p_info, p_param);
+    json_network_info_unlock_const(&p_info);
 }
 
 void

--- a/src/json_network_info.c
+++ b/src/json_network_info.c
@@ -334,6 +334,15 @@ json_network_info_update(
 static void
 json_network_info_do_set_extra_info(json_network_info_t* const p_info, const void* const p_param)
 {
+    if (NULL == p_info)
+    {
+        // p_info is set to NULL when the lock could not be acquired within the timeout when calling the functions
+        // 'json_network_info_do_action_...'.
+        // However, this function is only used with 'json_network_info_do_action...',
+        // which waits for an infinite amount of time. Therefore, p_info should never be set to NULL here.
+        // This check is for static analysis only.
+        return;
+    }
     const json_network_info_set_extra_t* const p_extra_info = p_param;
     snprintf(
         p_info->extra_info,

--- a/src/json_network_info.h
+++ b/src/json_network_info.h
@@ -132,8 +132,9 @@ json_network_info_do_action_with_timeout_without_param(
  * @param cb_func - a callback-function to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  * @param ticks_to_wait - timeout waiting for data access to be granted (use OS_DELTA_TICKS_INFINITE for infinite).
+ * @return true if access was granted and action was performed, false otherwise
  */
-void
+bool
 json_network_info_do_const_action_with_timeout(
     json_network_info_do_const_action_callback_t cb_func,
     void* const                                  p_param,

--- a/src/json_network_info.h
+++ b/src/json_network_info.h
@@ -85,7 +85,7 @@ void
 json_network_info_deinit(void);
 
 /**
- * @brief Try to lock access to json_network_info in read-write mode and perform specified action.
+ * @brief Try to lock access to json_network_info in read-write mode and perform the specified action.
  * @note If access could not be gained within the specified timeout,
  *          then the callback-function will be called with NULL as the first argument.
  * @param cb_func - a callback-function to call after granting access to json_network_info
@@ -99,9 +99,9 @@ json_network_info_do_action_with_timeout(
     const os_delta_ticks_t                 ticks_to_wait);
 
 /**
- * @brief Try to lock access to json_network_info in read-write mode and perform specified action.
+ * @brief Try to lock access to json_network_info in read-write mode and perform the specified action.
  * @note If access could not be gained within the specified timeout,
- *          then the callback-function will be called with NULL as the first argument.
+ *       then the callback-function will be called with NULL as the first argument.
  * @param cb_func - a callback-function (with const-param) to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  * @param ticks_to_wait - timeout waiting for data access to be granted (use OS_DELTA_TICKS_INFINITE for infinite).
@@ -113,11 +113,10 @@ json_network_info_do_action_with_timeout_with_const_param(
     const os_delta_ticks_t                                  ticks_to_wait);
 
 /**
- * @brief Try to lock access to json_network_info in read-write mode and perform specified action.
+ * @brief Try to lock access to json_network_info in read-write mode and perform the specified action.
  * @note If access could not be gained within the specified timeout,
- *          then the callback-function will be called with NULL as the first argument.
+ *       then the callback-function will be called with NULL as the first argument.
  * @param cb_func - a callback-function (without param) to call after granting access to json_network_info
- * @param p_param - pointer to be passed to the callback-function
  * @param ticks_to_wait - timeout waiting for data access to be granted (use OS_DELTA_TICKS_INFINITE for infinite).
  */
 void
@@ -126,24 +125,23 @@ json_network_info_do_action_with_timeout_without_param(
     const os_delta_ticks_t                               ticks_to_wait);
 
 /**
- * @brief Try to lock access to json_network_info in read-only mode and perform specified action.
+ * @brief Try to lock access to json_network_info in read-only mode and perform the specified action.
  * @note If access could not be gained within the specified timeout,
- *          then the callback-function will be called with NULL as the first argument.
+ *       then the callback-function will be called with NULL as the first argument.
  * @param cb_func - a callback-function to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  * @param ticks_to_wait - timeout waiting for data access to be granted (use OS_DELTA_TICKS_INFINITE for infinite).
- * @return true if access was granted and action was performed, false otherwise
  */
-bool
+void
 json_network_info_do_const_action_with_timeout(
     json_network_info_do_const_action_callback_t cb_func,
     void* const                                  p_param,
     const os_delta_ticks_t                       ticks_to_wait);
 
 /**
- * @brief Try to lock access to json_network_info in read-only mode and perform specified action.
+ * @brief Try to lock access to json_network_info in read-only mode and perform the specified action.
  * @note If access could not be gained within the specified timeout,
- *          then the callback-function will be called with NULL as the first argument.
+ *       then the callback-function will be called with NULL as the first argument.
  * @param cb_func - a callback-function (with const-param) to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  * @param ticks_to_wait - timeout waiting for data access to be granted (use OS_DELTA_TICKS_INFINITE for infinite).
@@ -155,7 +153,7 @@ json_network_info_do_const_action_with_timeout_with_const_param(
     const os_delta_ticks_t                                        ticks_to_wait);
 
 /**
- * @brief Lock access to json_network_info in read-write mode and perform specified action.
+ * @brief Lock access to json_network_info in read-write mode and perform the specified action.
  * @param cb_func - a callback-function to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  */
@@ -163,7 +161,7 @@ void
 json_network_info_do_action(json_network_info_do_action_callback_t cb_func, void* const p_param);
 
 /**
- * @brief Lock access to json_network_info in read-write mode and perform specified action.
+ * @brief Lock access to json_network_info in read-write mode and perform the specified action.
  * @param cb_func - a callback-function (with const-param) to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  */
@@ -173,15 +171,14 @@ json_network_info_do_action_with_const_param(
     const void* const                                       p_param);
 
 /**
- * @brief Lock access to json_network_info in read-write mode and perform specified action.
- * @param cb_func - a callback-function without param to call after granting access to json_network_info
- * @param p_param - pointer to be passed to the callback-function
+ * @brief Lock access to json_network_info in read-write mode and perform the specified action.
+ * @param cb_func - a callback-function without a param to call after granting access to json_network_info
  */
 void
 json_network_info_do_action_without_param(json_network_info_do_action_callback_without_param_t cb_func);
 
 /**
- * @brief Lock access to json_network_info in read-only mode and perform specified action.
+ * @brief Lock access to json_network_info in read-only mode and perform the specified action.
  * @param cb_func - a callback-function to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  */
@@ -189,7 +186,7 @@ void
 json_network_info_do_const_action(json_network_info_do_const_action_callback_t cb_func, void* const p_param);
 
 /**
- * @brief Lock access to json_network_info in read-only mode and perform specified action.
+ * @brief Lock access to json_network_info in read-only mode and perform the specified action.
  * @param cb_func - a callback-function (with const-param) to call after granting access to json_network_info
  * @param p_param - pointer to be passed to the callback-function
  */
@@ -199,13 +196,13 @@ json_network_info_do_const_action_with_const_param(
     const void* const                                             p_param);
 
 /**
- * @brief Generates the connection status json: ssid and IP addresses.
+ * @brief Generates the connection status JSON: ssid and IP addresses.
  */
 void
 json_network_info_generate(http_server_resp_status_json_t* const p_resp_status_json);
 
 /**
- * @brief Generates the connection status json: ssid and IP addresses.
+ * @brief Generates the connection status JSON: ssid and IP addresses.
  */
 void
 json_network_info_do_generate_internal(
@@ -228,15 +225,15 @@ void
 json_network_set_extra_info(const char* const p_extra);
 
 /**
- * @brief Clears the connection status json.
- * @note This is not thread-safe and should be called only if wifi_manager_lock_json_buffer call is successful.
+ * @brief Clears the connection status JSON.
+ * @note This is not thread-safe and should be called only if the wifi_manager_lock_json_buffer call is successful.
  */
 void
 json_network_info_clear(void);
 
 /**
- * @brief Updates the connection status json - sets reason to "user disconnect".
- * @note This is not thread-safe and should be called only if wifi_manager_lock_json_buffer call is successful.
+ * @brief Updates the connection status JSON - sets reason to "user disconnect".
+ * @note This is not thread-safe and should be called only if the wifi_manager_lock_json_buffer call is successful.
  */
 void
 json_network_info_set_reason_user_disconnect(void);

--- a/tests/test_json_network_info/test_json_network_info.cpp
+++ b/tests/test_json_network_info/test_json_network_info.cpp
@@ -469,3 +469,94 @@ TEST_F(
     ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }
+
+TEST_F(TestJsonNetworkInfo, test_do_action_wrapper_invokes_callback_with_non_null_info) // NOLINT
+{
+    json_network_info_do_action(&test_cb_do_action_with_timeout, nullptr);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_FALSE(this->m_callback_info_is_null);
+    ASSERT_EQ(200, this->m_callback_http_resp_code);
+    ASSERT_EQ(1, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(TestJsonNetworkInfo, test_do_const_action_wrapper_invokes_callback_with_non_null_info) // NOLINT
+{
+    json_network_info_do_const_action(&test_cb_do_const_action_with_timeout, nullptr);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_FALSE(this->m_callback_info_is_null);
+    ASSERT_EQ(200, this->m_callback_http_resp_code);
+    ASSERT_EQ(1, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(TestJsonNetworkInfo, test_set_reason_user_disconnect_updates_json_reason) // NOLINT
+{
+    json_network_info_set_reason_user_disconnect();
+    const string json_str = json_network_info_get();
+    ASSERT_EQ(
+        string("{"
+               "\"ssid\":null,"
+               "\"ip\":\"\","
+               "\"netmask\":\"\","
+               "\"gw\":\"\","
+               "\"dhcp\":\"\","
+               "\"urc\":2"
+               "}\n"),
+        json_str);
+}
+
+TEST_F(TestJsonNetworkInfo, test_update_with_null_network_info_clears_network_fields) // NOLINT
+{
+    const wifiman_wifi_ssid_t ssid = { "test_ssid" };
+    json_network_info_update(&ssid, nullptr, UPDATE_FAILED_ATTEMPT);
+    const string json_str = json_network_info_get();
+    ASSERT_EQ(
+        string("{"
+               "\"ssid\":\"test_ssid\","
+               "\"ip\":\"\","
+               "\"netmask\":\"\","
+               "\"gw\":\"\","
+               "\"dhcp\":\"\","
+               "\"urc\":1"
+               "}\n"),
+        json_str);
+}
+
+TEST_F(TestJsonNetworkInfo, test_set_extra_info_is_appended_when_reason_is_defined) // NOLINT
+{
+    const network_info_str_t network_info = {
+        { "192.168.0.50" },
+        { "192.168.0.1" },
+        { "255.255.255.0" },
+        { "192.168.0.2" },
+    };
+    const wifiman_wifi_ssid_t ssid = { "test_ssid" };
+    json_network_info_update(&ssid, &network_info, UPDATE_CONNECTION_OK);
+    json_network_set_extra_info("\"rssi\":-42");
+    const string json_str = json_network_info_get();
+    ASSERT_EQ(
+        string("{"
+               "\"ssid\":\"test_ssid\","
+               "\"ip\":\"192.168.0.50\","
+               "\"netmask\":\"255.255.255.0\","
+               "\"gw\":\"192.168.0.1\","
+               "\"dhcp\":\"192.168.0.2\","
+               "\"urc\":0,"
+               "\"extra\":{\"rssi\":-42}"
+               "}\n"),
+        json_str);
+}
+
+TEST_F(TestJsonNetworkInfo, test_set_extra_info_is_generated_when_reason_is_undefined) // NOLINT
+{
+    json_network_set_extra_info("\"state\":\"idle\"");
+    const string json_str = json_network_info_get();
+    ASSERT_EQ(string("{\"extra\":{\"state\":\"idle\"}}\n"), json_str);
+}
+
+TEST_F(TestJsonNetworkInfo, test_set_extra_info_null_clears_extra_section) // NOLINT
+{
+    json_network_set_extra_info("\"state\":\"idle\"");
+    json_network_set_extra_info(nullptr);
+    const string json_str = json_network_info_get();
+    ASSERT_EQ(string("{}\n"), json_str);
+}

--- a/tests/test_json_network_info/test_json_network_info.cpp
+++ b/tests/test_json_network_info/test_json_network_info.cpp
@@ -66,8 +66,10 @@ protected:
         json_network_info_init();
         g_pTestClass = this;
 
-        this->m_malloc_cnt         = 0;
-        this->m_malloc_fail_on_cnt = 0;
+        this->m_malloc_cnt                     = 0;
+        this->m_malloc_fail_on_cnt             = 0;
+        this->m_mutex_lock_with_timeout_result = true;
+        this->m_mutex_unlock_call_cnt          = 0;
     }
 
     void
@@ -85,6 +87,8 @@ public:
     MemAllocTrace m_mem_alloc_trace {};
     uint32_t      m_malloc_cnt {};
     uint32_t      m_malloc_fail_on_cnt {};
+    bool          m_mutex_lock_with_timeout_result { true };
+    uint32_t      m_mutex_unlock_call_cnt {};
 };
 
 TestJsonNetworkInfo::TestJsonNetworkInfo() = default;
@@ -144,12 +148,23 @@ os_mutex_delete(os_mutex_t* p_mutex)
 bool
 os_mutex_lock_with_timeout(os_mutex_t const h_mutex, const os_delta_ticks_t ticks_to_wait)
 {
-    return true;
+    (void)h_mutex;
+    (void)ticks_to_wait;
+    if (nullptr == g_pTestClass)
+    {
+        return true;
+    }
+    return g_pTestClass->m_mutex_lock_with_timeout_result;
 }
 
 void
 os_mutex_unlock(os_mutex_t const h_mutex)
 {
+    (void)h_mutex;
+    if (nullptr != g_pTestClass)
+    {
+        ++g_pTestClass->m_mutex_unlock_call_cnt;
+    }
 }
 
 } // extern "C"
@@ -161,6 +176,57 @@ json_network_info_get(void)
     json_network_info_generate(&resp_status_json);
     string json_info_copy(resp_status_json.buf);
     return json_info_copy;
+}
+
+typedef struct callback_result_t
+{
+    bool called;
+    bool is_info_null;
+    int  http_resp_code;
+} callback_result_t;
+
+extern "C" void
+test_cb_do_action_with_timeout(json_network_info_t* const p_info, void* const p_param)
+{
+    callback_result_t* const p_result = static_cast<callback_result_t*>(p_param);
+    p_result->called                  = true;
+    p_result->is_info_null            = (nullptr == p_info);
+    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+}
+
+extern "C" void
+test_cb_do_action_with_timeout_with_const_param(json_network_info_t* const p_info, const void* const p_param)
+{
+    callback_result_t* const p_result = static_cast<callback_result_t*>(const_cast<void*>(p_param));
+    p_result->called                  = true;
+    p_result->is_info_null            = (nullptr == p_info);
+    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+}
+
+extern "C" void
+test_cb_do_action_with_timeout_without_param(json_network_info_t* const p_info)
+{
+    ASSERT_EQ(nullptr, p_info);
+}
+
+extern "C" void
+test_cb_do_const_action_with_timeout(const json_network_info_t* const p_info, void* const p_param)
+{
+    callback_result_t* const p_result = static_cast<callback_result_t*>(p_param);
+    p_result->called                  = true;
+    p_result->is_info_null            = (nullptr == p_info);
+    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+}
+
+extern "C" void
+test_cb_do_const_action_with_timeout_with_const_param(
+    const json_network_info_t* const p_info,
+    const void* const                p_param)
+{
+    callback_result_t* const p_result = static_cast<callback_result_t*>(const_cast<void*>(p_param));
+    p_result->called                  = true;
+    p_result->is_info_null            = (nullptr == p_info);
+    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
 }
 
 /*** Unit-Tests *******************************************************************************************************/
@@ -341,4 +407,65 @@ TEST_F(TestJsonNetworkInfo, test_generate_lost_connection) // NOLINT
                "\"urc\":3"
                "}\n"),
         json_str);
+}
+
+TEST_F(TestJsonNetworkInfo, test_do_action_with_timeout_lock_failure_invokes_callback_with_null) // NOLINT
+{
+    this->m_mutex_lock_with_timeout_result = false;
+    callback_result_t result               = {};
+    json_network_info_do_action_with_timeout(&test_cb_do_action_with_timeout, &result, 1U);
+    ASSERT_TRUE(result.called);
+    ASSERT_TRUE(result.is_info_null);
+    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(
+    TestJsonNetworkInfo,
+    test_do_action_with_timeout_with_const_param_lock_failure_invokes_callback_with_null) // NOLINT
+{
+    this->m_mutex_lock_with_timeout_result = false;
+    callback_result_t result               = {};
+    json_network_info_do_action_with_timeout_with_const_param(
+        &test_cb_do_action_with_timeout_with_const_param,
+        &result,
+        1U);
+    ASSERT_TRUE(result.called);
+    ASSERT_TRUE(result.is_info_null);
+    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(TestJsonNetworkInfo, test_do_action_with_timeout_without_param_lock_failure_invokes_callback_with_null) // NOLINT
+{
+    this->m_mutex_lock_with_timeout_result = false;
+    json_network_info_do_action_with_timeout_without_param(&test_cb_do_action_with_timeout_without_param, 1U);
+    ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(TestJsonNetworkInfo, test_do_const_action_with_timeout_lock_failure_invokes_callback_with_null) // NOLINT
+{
+    this->m_mutex_lock_with_timeout_result = false;
+    callback_result_t result               = {};
+    json_network_info_do_const_action_with_timeout(&test_cb_do_const_action_with_timeout, &result, 1U);
+    ASSERT_TRUE(result.called);
+    ASSERT_TRUE(result.is_info_null);
+    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
+}
+
+TEST_F(
+    TestJsonNetworkInfo,
+    test_do_const_action_with_timeout_with_const_param_lock_failure_invokes_callback_with_null) // NOLINT
+{
+    this->m_mutex_lock_with_timeout_result = false;
+    callback_result_t result               = {};
+    json_network_info_do_const_action_with_timeout_with_const_param(
+        &test_cb_do_const_action_with_timeout_with_const_param,
+        &result,
+        1U);
+    ASSERT_TRUE(result.called);
+    ASSERT_TRUE(result.is_info_null);
+    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }

--- a/tests/test_json_network_info/test_json_network_info.cpp
+++ b/tests/test_json_network_info/test_json_network_info.cpp
@@ -70,6 +70,9 @@ protected:
         this->m_malloc_fail_on_cnt             = 0;
         this->m_mutex_lock_with_timeout_result = true;
         this->m_mutex_unlock_call_cnt          = 0;
+        this->m_callback_called                = false;
+        this->m_callback_info_is_null          = false;
+        this->m_callback_http_resp_code        = 0;
     }
 
     void
@@ -89,6 +92,9 @@ public:
     uint32_t      m_malloc_fail_on_cnt {};
     bool          m_mutex_lock_with_timeout_result { true };
     uint32_t      m_mutex_unlock_call_cnt {};
+    bool          m_callback_called {};
+    bool          m_callback_info_is_null {};
+    int           m_callback_http_resp_code {};
 };
 
 TestJsonNetworkInfo::TestJsonNetworkInfo() = default;
@@ -178,44 +184,39 @@ json_network_info_get(void)
     return json_info_copy;
 }
 
-typedef struct callback_result_t
-{
-    bool called;
-    bool is_info_null;
-    int  http_resp_code;
-} callback_result_t;
-
 extern "C" void
 test_cb_do_action_with_timeout(json_network_info_t* const p_info, void* const p_param)
 {
-    callback_result_t* const p_result = static_cast<callback_result_t*>(p_param);
-    p_result->called                  = true;
-    p_result->is_info_null            = (nullptr == p_info);
-    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+    (void)p_param;
+    g_pTestClass->m_callback_called         = true;
+    g_pTestClass->m_callback_info_is_null   = (nullptr == p_info);
+    g_pTestClass->m_callback_http_resp_code = (nullptr == p_info) ? 503 : 200;
 }
 
 extern "C" void
 test_cb_do_action_with_timeout_with_const_param(json_network_info_t* const p_info, const void* const p_param)
 {
-    callback_result_t* const p_result = static_cast<callback_result_t*>(const_cast<void*>(p_param));
-    p_result->called                  = true;
-    p_result->is_info_null            = (nullptr == p_info);
-    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+    (void)p_param;
+    g_pTestClass->m_callback_called         = true;
+    g_pTestClass->m_callback_info_is_null   = (nullptr == p_info);
+    g_pTestClass->m_callback_http_resp_code = (nullptr == p_info) ? 503 : 200;
 }
 
 extern "C" void
 test_cb_do_action_with_timeout_without_param(json_network_info_t* const p_info)
 {
-    ASSERT_EQ(nullptr, p_info);
+    g_pTestClass->m_callback_called         = true;
+    g_pTestClass->m_callback_info_is_null   = (nullptr == p_info);
+    g_pTestClass->m_callback_http_resp_code = (nullptr == p_info) ? 503 : 200;
 }
 
 extern "C" void
 test_cb_do_const_action_with_timeout(const json_network_info_t* const p_info, void* const p_param)
 {
-    callback_result_t* const p_result = static_cast<callback_result_t*>(p_param);
-    p_result->called                  = true;
-    p_result->is_info_null            = (nullptr == p_info);
-    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+    (void)p_param;
+    g_pTestClass->m_callback_called         = true;
+    g_pTestClass->m_callback_info_is_null   = (nullptr == p_info);
+    g_pTestClass->m_callback_http_resp_code = (nullptr == p_info) ? 503 : 200;
 }
 
 extern "C" void
@@ -223,10 +224,10 @@ test_cb_do_const_action_with_timeout_with_const_param(
     const json_network_info_t* const p_info,
     const void* const                p_param)
 {
-    callback_result_t* const p_result = static_cast<callback_result_t*>(const_cast<void*>(p_param));
-    p_result->called                  = true;
-    p_result->is_info_null            = (nullptr == p_info);
-    p_result->http_resp_code          = (nullptr == p_info) ? 503 : 200;
+    (void)p_param;
+    g_pTestClass->m_callback_called         = true;
+    g_pTestClass->m_callback_info_is_null   = (nullptr == p_info);
+    g_pTestClass->m_callback_http_resp_code = (nullptr == p_info) ? 503 : 200;
 }
 
 /*** Unit-Tests *******************************************************************************************************/
@@ -412,11 +413,10 @@ TEST_F(TestJsonNetworkInfo, test_generate_lost_connection) // NOLINT
 TEST_F(TestJsonNetworkInfo, test_do_action_with_timeout_lock_failure_invokes_callback_with_null) // NOLINT
 {
     this->m_mutex_lock_with_timeout_result = false;
-    callback_result_t result               = {};
-    json_network_info_do_action_with_timeout(&test_cb_do_action_with_timeout, &result, 1U);
-    ASSERT_TRUE(result.called);
-    ASSERT_TRUE(result.is_info_null);
-    ASSERT_EQ(503, result.http_resp_code);
+    json_network_info_do_action_with_timeout(&test_cb_do_action_with_timeout, nullptr, 1U);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_TRUE(this->m_callback_info_is_null);
+    ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }
 
@@ -425,14 +425,13 @@ TEST_F(
     test_do_action_with_timeout_with_const_param_lock_failure_invokes_callback_with_null) // NOLINT
 {
     this->m_mutex_lock_with_timeout_result = false;
-    callback_result_t result               = {};
     json_network_info_do_action_with_timeout_with_const_param(
         &test_cb_do_action_with_timeout_with_const_param,
-        &result,
+        nullptr,
         1U);
-    ASSERT_TRUE(result.called);
-    ASSERT_TRUE(result.is_info_null);
-    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_TRUE(this->m_callback_info_is_null);
+    ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }
 
@@ -440,17 +439,19 @@ TEST_F(TestJsonNetworkInfo, test_do_action_with_timeout_without_param_lock_failu
 {
     this->m_mutex_lock_with_timeout_result = false;
     json_network_info_do_action_with_timeout_without_param(&test_cb_do_action_with_timeout_without_param, 1U);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_TRUE(this->m_callback_info_is_null);
+    ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }
 
 TEST_F(TestJsonNetworkInfo, test_do_const_action_with_timeout_lock_failure_invokes_callback_with_null) // NOLINT
 {
     this->m_mutex_lock_with_timeout_result = false;
-    callback_result_t result               = {};
-    json_network_info_do_const_action_with_timeout(&test_cb_do_const_action_with_timeout, &result, 1U);
-    ASSERT_TRUE(result.called);
-    ASSERT_TRUE(result.is_info_null);
-    ASSERT_EQ(503, result.http_resp_code);
+    json_network_info_do_const_action_with_timeout(&test_cb_do_const_action_with_timeout, nullptr, 1U);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_TRUE(this->m_callback_info_is_null);
+    ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }
 
@@ -459,13 +460,12 @@ TEST_F(
     test_do_const_action_with_timeout_with_const_param_lock_failure_invokes_callback_with_null) // NOLINT
 {
     this->m_mutex_lock_with_timeout_result = false;
-    callback_result_t result               = {};
     json_network_info_do_const_action_with_timeout_with_const_param(
         &test_cb_do_const_action_with_timeout_with_const_param,
-        &result,
+        nullptr,
         1U);
-    ASSERT_TRUE(result.called);
-    ASSERT_TRUE(result.is_info_null);
-    ASSERT_EQ(503, result.http_resp_code);
+    ASSERT_TRUE(this->m_callback_called);
+    ASSERT_TRUE(this->m_callback_info_is_null);
+    ASSERT_EQ(503, this->m_callback_http_resp_code);
     ASSERT_EQ(0, this->m_mutex_unlock_call_cnt);
 }


### PR DESCRIPTION
* Fixes `json_network_info_do_const_action_with_timeout` (and other similar API) to call a callback with NULL argument in case when the lock was not acquired.
* Increases the timeout to 500ms when fetching status JSON and ensures an HTTP 503 error is returned if the operation times out.
* Adds error logging for unsupported HTTP response codes in the netconn response handler.