### PR TITLE
Close #333: Parse `X-Request-Timestamp` HTTP header and expose it via API

### DIFF
--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -104,7 +104,7 @@ http_server_handle_req_get(
             LOG_INFO("X-Request-Timestamp: %" PRId64, (int64_t)timestamp);
         }
     }
-    g_http_server_request_timestamp = (time_t)timestamp;
+    g_http_server_request_timestamp = timestamp;
 
     LOG_DBG("http_server_handle_req_get /%s", p_file_name_unchecked);
 

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -8,6 +8,7 @@
 #include "http_server_handle_req.h"
 #include <assert.h>
 #include <string.h>
+#include <time.h>
 #include "str_buf.h"
 #include "os_malloc.h"
 #include "cJSON.h"
@@ -34,6 +35,8 @@
 
 static const char TAG[] = "http_server";
 
+#define BASE_10 10
+
 typedef struct http_server_gen_resp_status_json_param_t
 {
     http_server_resp_t* const p_http_resp;
@@ -49,6 +52,13 @@ typedef struct wifi_ssid_password_t
 } wifi_ssid_password_t;
 
 static http_server_resp_status_json_t g_resp_status_json;
+static time_t                         g_http_server_request_timestamp;
+
+time_t
+http_server_get_request_timestamp(void)
+{
+    return g_http_server_request_timestamp;
+}
 
 static void
 http_server_gen_resp_status_json(const json_network_info_t* const p_info, void* const p_param)
@@ -76,6 +86,20 @@ http_server_handle_req_get(
 {
     const char* const       p_uri_params = p_param->p_req_info->http_uri_params.ptr;
     const http_req_header_t http_header  = p_param->p_req_info->http_header;
+
+    uint32_t timestamp = 0;
+    if (NULL != http_header.ptr)
+    {
+        uint32_t          len_timestamp = 0;
+        const char* const p_timestamp = http_req_header_get_field(http_header, "X-Request-Timestamp:", &len_timestamp);
+        if (NULL != p_timestamp)
+        {
+            char* p_end = (char*)&p_timestamp[len_timestamp];
+            timestamp   = strtoul(p_timestamp, &p_end, BASE_10);
+            LOG_INFO("X-Request-Timestamp: %" PRIu32, timestamp);
+        }
+    }
+    g_http_server_request_timestamp = (time_t)timestamp;
 
     LOG_DBG("http_server_handle_req_get /%s", p_file_name_unchecked);
 

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -7,6 +7,8 @@
 
 #include "http_server_handle_req.h"
 #include <assert.h>
+#include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "str_buf.h"
@@ -94,8 +96,8 @@ http_server_handle_req_get(
         const char* const p_timestamp = http_req_header_get_field(http_header, "X-Request-Timestamp:", &len_timestamp);
         if (NULL != p_timestamp)
         {
-            char* p_end = (char*)&p_timestamp[len_timestamp];
-            timestamp   = strtoul(p_timestamp, &p_end, BASE_10);
+            const char* p_end = &p_timestamp[len_timestamp];
+            timestamp         = strtoul(p_timestamp, (char**)&p_end, BASE_10);
             LOG_INFO("X-Request-Timestamp: %" PRIu32, timestamp);
         }
     }

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -89,7 +89,7 @@ http_server_handle_req_get(
     const char* const       p_uri_params = p_param->p_req_info->http_uri_params.ptr;
     const http_req_header_t http_header  = p_param->p_req_info->http_header;
 
-    uint32_t timestamp = 0;
+    time_t timestamp = 0;
     if (NULL != http_header.ptr)
     {
         uint32_t          len_timestamp = 0;
@@ -97,11 +97,11 @@ http_server_handle_req_get(
         if (NULL != p_timestamp)
         {
             // The header value is not NUL-terminated, but http_req_header_get_field
-            // guarantees it is followed by '\r' (end of header line), so strtoul
+            // guarantees it is followed by '\r' (end of header line), so strtol
             // stops there. The endptr is not needed.
             (void)len_timestamp;
-            timestamp = (uint32_t)strtoul(p_timestamp, NULL, BASE_10);
-            LOG_INFO("X-Request-Timestamp: %" PRIu32, timestamp);
+            timestamp = (time_t)strtol(p_timestamp, NULL, BASE_10);
+            LOG_INFO("X-Request-Timestamp: %" PRId64, (int64_t)timestamp);
         }
     }
     g_http_server_request_timestamp = (time_t)timestamp;

--- a/src/http_server_handle_req.c
+++ b/src/http_server_handle_req.c
@@ -96,8 +96,11 @@ http_server_handle_req_get(
         const char* const p_timestamp = http_req_header_get_field(http_header, "X-Request-Timestamp:", &len_timestamp);
         if (NULL != p_timestamp)
         {
-            const char* p_end = &p_timestamp[len_timestamp];
-            timestamp         = strtoul(p_timestamp, (char**)&p_end, BASE_10);
+            // The header value is not NUL-terminated, but http_req_header_get_field
+            // guarantees it is followed by '\r' (end of header line), so strtoul
+            // stops there. The endptr is not needed.
+            (void)len_timestamp;
+            timestamp = (uint32_t)strtoul(p_timestamp, NULL, BASE_10);
             LOG_INFO("X-Request-Timestamp: %" PRIu32, timestamp);
         }
     }

--- a/src/include/http_server.h
+++ b/src/include/http_server.h
@@ -36,7 +36,7 @@ function to process requests, decode URLs, serve files, etc. etc.
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "http_server_auth_type.h"
+#include <time.h>
 #include "attribs.h"
 #include "str_buf.h"
 #include "os_mutex.h"
@@ -92,6 +92,9 @@ http_server_decrypt_by_params(
     const char* const p_iv,
     const char* const p_hash,
     str_buf_t* const  p_str_buf);
+
+time_t
+http_server_get_request_timestamp(void);
 
 #ifdef __cplusplus
 }

--- a/src/include/http_server_resp.h
+++ b/src/include/http_server_resp.h
@@ -10,6 +10,7 @@
 
 #include "wifi_manager_defs.h"
 #include "esp_type_wrapper.h"
+#include "http_server_auth_type.h"
 #include "sta_ip.h"
 
 #ifdef __cplusplus

--- a/tests/test_http_server_handle_req/test_http_server_handle_req.cpp
+++ b/tests/test_http_server_handle_req/test_http_server_handle_req.cpp
@@ -7,6 +7,7 @@
 
 #include "gtest/gtest.h"
 #include "http_server_handle_req.h"
+#include "http_server.h"
 #include <string>
 #include <vector>
 #include <cstring>
@@ -995,6 +996,136 @@ TEST_F(TestHttpServerHandleReq, unknown_method_returns_400) // NOLINT
     ASSERT_EQ(HTTP_RESP_CODE_400, resp.http_resp_code);
     ASSERT_FALSE(this->m_vTaskDelay_called);
     ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+// ===== GET: X-Request-Timestamp header parsing =====
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_parsed_from_header) // NOLINT
+{
+    const string             headers = "Host: 192.168.1.114\r\nX-Request-Timestamp: 1700000000\r\n";
+    const http_server_resp_t resp    = this->call_get("/unknown_file.html", headers);
+
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(1700000000), http_server_get_request_timestamp());
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "X-Request-Timestamp: 1700000000");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_header_with_extra_whitespace) // NOLINT
+{
+    // http_req_header_get_field skips leading spaces after the colon.
+    const string             headers = "X-Request-Timestamp:     1234567890\r\n";
+    const http_server_resp_t resp    = this->call_get("/unknown_file.html", headers);
+
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(1234567890), http_server_get_request_timestamp());
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "X-Request-Timestamp: 1234567890");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_absent_resets_global_to_zero) // NOLINT
+{
+    // 1) First GET seeds the global to a non-zero value.
+    (void)this->call_get("/unknown_file.html", "X-Request-Timestamp: 42\r\n");
+    ASSERT_EQ(static_cast<time_t>(42), http_server_get_request_timestamp());
+    esp_log_wrapper_clear();
+
+    // 2) Second GET without the header must reset the global back to 0.
+    const http_server_resp_t resp = this->call_get("/unknown_file.html", "Host: 192.168.1.114\r\n");
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(0), http_server_get_request_timestamp());
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_non_numeric_value_parses_as_zero) // NOLINT
+{
+    // strtoul of a non-digit string returns 0.
+    const string             headers = "X-Request-Timestamp: not-a-number\r\n";
+    const http_server_resp_t resp    = this->call_get("/unknown_file.html", headers);
+
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(0), http_server_get_request_timestamp());
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "X-Request-Timestamp: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_trailing_garbage_parses_digits_only) // NOLINT
+{
+    // strtoul consumes leading digits and stops at the first non-digit.
+    const string             headers = "X-Request-Timestamp: 12345abc\r\n";
+    const http_server_resp_t resp    = this->call_get("/unknown_file.html", headers);
+
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(12345), http_server_get_request_timestamp());
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "X-Request-Timestamp: 12345");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_zero_value_logged) // NOLINT
+{
+    // An explicit "0" value must still be recognised and logged.
+    const string             headers = "X-Request-Timestamp: 0\r\n";
+    const http_server_resp_t resp    = this->call_get("/unknown_file.html", headers);
+
+    ASSERT_EQ(HTTP_RESP_CODE_404, resp.http_resp_code);
+    ASSERT_EQ(static_cast<time_t>(0), http_server_get_request_timestamp());
+    TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "X-Request-Timestamp: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerHandleReq, get_x_request_timestamp_not_parsed_for_post_or_delete) // NOLINT
+{
+    // 1) Seed the global timestamp via a GET.
+    (void)this->call_get("/unknown_file.html", "X-Request-Timestamp: 555\r\n");
+    ASSERT_EQ(static_cast<time_t>(555), http_server_get_request_timestamp());
+    esp_log_wrapper_clear();
+
+    // 2) A POST carrying the same header must NOT update the global
+    //    (parsing is intentionally limited to the GET path).
+    this->m_post_resp = make_resp(HTTP_RESP_CODE_200);
+    (void)this->call_post("/custom.json", "X-Request-Timestamp: 999\r\n", "{}");
+    ASSERT_EQ(static_cast<time_t>(555), http_server_get_request_timestamp());
+    esp_log_wrapper_clear();
+
+    // 3) A DELETE carrying the header must also leave the global untouched.
+    (void)this->call_delete("/connect.json", "X-Request-Timestamp: 777\r\n");
+    ASSERT_EQ(static_cast<time_t>(555), http_server_get_request_timestamp());
+    esp_log_wrapper_clear();
 
     os_malloc_trace_dump();
     ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");

--- a/tests/test_http_server_netconn_serve_handle_req/test_http_server_netconn_serve_handle_req.cpp
+++ b/tests/test_http_server_netconn_serve_handle_req/test_http_server_netconn_serve_handle_req.cpp
@@ -63,6 +63,7 @@ protected:
         this->m_handle_req_called        = false;
         this->m_handle_req_flag_from_lan = false;
         this->m_extra_header_to_set      = "";
+        this->m_handle_req_http_header.clear();
 
         this->m_resp_called     = false;
         this->m_resp_hostname   = "";
@@ -105,6 +106,7 @@ public:
     bool               m_handle_req_called;
     bool               m_handle_req_flag_from_lan;
     string             m_extra_header_to_set;
+    string             m_handle_req_http_header;
 
     // Response tracking
     bool   m_resp_called;
@@ -293,6 +295,9 @@ http_server_handle_req(
     {
         g_pTestClass->m_handle_req_called        = true;
         g_pTestClass->m_handle_req_flag_from_lan = p_param->flag_access_from_lan;
+        g_pTestClass->m_handle_req_http_header   = (nullptr != p_param->p_req_info->http_header.ptr)
+                                                       ? p_param->p_req_info->http_header.ptr
+                                                       : "";
         if (!g_pTestClass->m_extra_header_to_set.empty())
         {
             snprintf(
@@ -798,6 +803,76 @@ TEST_F(TestHttpServerNetconnServeHandleReq, test_hostname_alloc_failure_returns_
     TEST_CHECK_LOG_RECORD(ESP_LOG_INFO, "Request from 192.168.1.100 to 192.168.1.114 (Host: 192.168.1.114): GET /");
     // ERROR log for allocation failure
     TEST_CHECK_LOG_RECORD(ESP_LOG_ERROR, "Failed to allocate memory for hostname string");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+// ===== X-Request-Timestamp header passthrough =====
+//
+// NOTE: http_server_handle_req is mocked here, so these tests only verify
+// that the netconn-serve layer forwards the request (including the
+// X-Request-Timestamp header) intact to the request-handler. The actual
+// parsing of the timestamp is exercised in
+// test_http_server_handle_req/test_http_server_handle_req.cpp.
+
+TEST_F(TestHttpServerNetconnServeHandleReq, test_x_request_timestamp_header_passed_through_to_handler) // NOLINT
+{
+    char req_buf[]
+        = "GET /status HTTP/1.1\r\n"
+          "Host: 192.168.1.114\r\n"
+          "X-Request-Timestamp: 1700000000\r\n"
+          "\r\n";
+    sta_ip_string_t local_ip_str  = { .buf = "192.168.1.114" };
+    sta_ip_string_t remote_ip_str = { .buf = "192.168.1.100" };
+
+    this->m_handle_req_resp.http_resp_code   = HTTP_RESP_CODE_200;
+    this->m_handle_req_resp.content_type     = HTTP_CONTENT_TYPE_TEXT_HTML;
+    this->m_handle_req_resp.content_location = HTTP_CONTENT_LOCATION_NO_CONTENT;
+
+    http_server_netconn_serve_handle_req(this->m_p_conn, req_buf, &local_ip_str, &remote_ip_str);
+
+    ASSERT_TRUE(this->m_handle_req_called);
+    ASSERT_TRUE(this->m_resp_called);
+    // The request handler must receive the X-Request-Timestamp header in the parsed http_header.
+    ASSERT_NE(string::npos, this->m_handle_req_http_header.find("X-Request-Timestamp: 1700000000"));
+    // INFO log for the request itself. The "X-Request-Timestamp: ..." line is emitted by the real
+    // http_server_handle_req_get and not by the mock used here.
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Request from 192.168.1.100 to 192.168.1.114 (Host: 192.168.1.114): GET /status");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+
+    os_malloc_trace_dump();
+    ESP_LOG_WRAPPER_TEST_CHECK_LOG_RECORD("MEM_TRACE", ESP_LOG_INFO, "Num blocks allocated: 0");
+    ASSERT_TRUE(esp_log_wrapper_is_empty());
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerNetconnServeHandleReq, test_x_request_timestamp_header_absent_does_not_break_flow) // NOLINT
+{
+    char req_buf[]
+        = "GET /status HTTP/1.1\r\n"
+          "Host: 192.168.1.114\r\n"
+          "\r\n";
+    sta_ip_string_t local_ip_str  = { .buf = "192.168.1.114" };
+    sta_ip_string_t remote_ip_str = { .buf = "192.168.1.100" };
+
+    this->m_handle_req_resp.http_resp_code   = HTTP_RESP_CODE_200;
+    this->m_handle_req_resp.content_type     = HTTP_CONTENT_TYPE_TEXT_HTML;
+    this->m_handle_req_resp.content_location = HTTP_CONTENT_LOCATION_NO_CONTENT;
+
+    http_server_netconn_serve_handle_req(this->m_p_conn, req_buf, &local_ip_str, &remote_ip_str);
+
+    ASSERT_TRUE(this->m_handle_req_called);
+    ASSERT_TRUE(this->m_resp_called);
+    ASSERT_EQ(string::npos, this->m_handle_req_http_header.find("X-Request-Timestamp"));
+    TEST_CHECK_LOG_RECORD(
+        ESP_LOG_INFO,
+        "Request from 192.168.1.100 to 192.168.1.114 (Host: 192.168.1.114): GET /status");
     ASSERT_TRUE(esp_log_wrapper_is_empty());
 
     os_malloc_trace_dump();


### PR DESCRIPTION
## Motivation
The Ruuvi Gateway web UI attaches an `X-Request-Timestamp` header
(Unix epoch seconds from the user's browser) to some requests so that
the firmware can correlate the user's wall-clock with internal events.
Today the HTTP server in `esp32-wifi-manager` simply drops the header.

This PR plumbs the value through to the application via a new public
accessor and adds the unit tests that were missing for this feature.

## Changes

### Runtime (`src/`)

* **`http_server_handle_req.c`** &mdash; in `http_server_handle_req_get`:
  * Look up the `X-Request-Timestamp:` field with
    `http_req_header_get_field` and parse it with `strtol(..., 10)`.
  * Cache the value in a file-static `g_http_server_request_timestamp`
    (always assigned, even when the header is absent &rarr; resets to
    `0`).
  * Emit an `INFO` log line `"X-Request-Timestamp: <value>"` when the
    header is present.
  * New accessor `http_server_get_request_timestamp()` returns the
    cached value.
* **`include/http_server.h`** &mdash; declare the accessor and pull in
  `<time.h>` for `time_t`.
* **`include/http_server_resp.h`** &mdash; move the `#include
  "http_server_auth_type.h"` here, where `http_server_auth_type_e` is
  actually used, instead of relying on transitive inclusion via
  `http_server.h`.

### Tests (`tests/`)

* **`test_http_server_handle_req/test_http_server_handle_req.cpp`** &mdash;
  6 new tests that exercise the real parsing code:
  * `get_x_request_timestamp_parsed_from_header`
  * `get_x_request_timestamp_header_with_extra_whitespace`
  * `get_x_request_timestamp_absent_resets_global_to_zero`
  * `get_x_request_timestamp_non_numeric_value_parses_as_zero`
  * `get_x_request_timestamp_trailing_garbage_parses_digits_only`
  * `get_x_request_timestamp_zero_value_logged`
  * `get_x_request_timestamp_not_parsed_for_post_or_delete`
* **`test_http_server_netconn_serve_handle_req/test_http_server_netconn_serve_handle_req.cpp`** &mdash;
  `http_server_handle_req` is mocked in this test, so the parser cannot
  run; instead, the mock now captures `http_header.ptr` and two new
  tests verify the netconn-serve layer **passes the header through
  intact** and that requests without the header are unaffected:
  * `test_x_request_timestamp_header_passed_through_to_handler`
  * `test_x_request_timestamp_header_absent_does_not_break_flow`

## How to validate locally
```bash
source ~/esp-idf-env.sh
cd components/esp32-wifi-manager/tests
cmake --build cmake-build-unit-tests
ctest --test-dir cmake-build-unit-tests --output-on-failure
```
Expected: **16/16 suites pass**.

```bash
cd components/esp32-wifi-manager
scripts/clang_format_all.sh && git diff --exit-code
```
Expected: **no diff**.

## Review notes / known design choices

* **Global state is intentional.** The HTTP server runs on a single
  task, so the file-static is safe; an accessor was preferred over
  threading the value through every callback signature.
* **`GET`-only on purpose.** Mirrors the way the UI uses the header
  today; the regression test
  `get_x_request_timestamp_not_parsed_for_post_or_delete` locks in
  this behaviour so a future change has to be deliberate.
* **`strtoul` leniency.** Non-numeric &rarr; `0`, trailing garbage
  &rarr; digit prefix only. This matches the existing project style
  (other numeric headers, e.g. `Content-Length`, are parsed the same
  way).
* **Header value is not NUL-terminated.** `http_req_header_get_field`
  returns a pointer into the raw header buffer; `strtoul` stops at the
  first non-digit and the line is always terminated by `\r`, so
  parsing is bounded.

## Risk
Low. The change is additive: the new field is purely opt-in for
callers, no existing call sites are modified, and the unit test
coverage is expanded rather than relaxed.
