### PR TITLE
fix(auth): #337 hide firmware versions from unauthenticated responses

### DIFF
--- a/src/http_server_handle_req_get_auth.c
+++ b/src/http_server_handle_req_get_auth.c
@@ -20,7 +20,8 @@ http_server_handle_req_get_auth_allow(const wifiman_hostinfo_t* const p_hostinfo
         p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_ALLOW,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }
 
@@ -35,7 +36,8 @@ http_server_resp_401_auth_basic(
         p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_BASIC,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        false);
     (void)snprintf(
         p_extra_header_fields->buf,
         sizeof(p_extra_header_fields->buf),
@@ -115,7 +117,8 @@ http_server_handle_req_get_auth_basic(
         p_param->p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_BASIC,
         p_param->flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }
 
@@ -175,7 +178,8 @@ http_server_handle_req_get_auth_digest(
         p_param->p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_DIGEST,
         p_param->flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }
 
@@ -239,7 +243,8 @@ http_server_handle_req_get_auth_ruuvi(
         p_param->p_hostinfo,
         auth_type,
         p_param->flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }
 
@@ -273,7 +278,8 @@ http_server_handle_req_get_or_check_auth(
                                                      p_param->p_hostinfo,
                                                      HTTP_SERVER_AUTH_TYPE_BEARER,
                                                      p_param->flag_access_from_lan,
-                                                     NULL)
+                                                     NULL,
+                                                     true)
                                                      ->buf);
             case HTTP_SERVER_AUTH_API_KEY_PROHIBITED:
                 *p_flag_access_by_bearer_token = true;
@@ -281,7 +287,8 @@ http_server_handle_req_get_or_check_auth(
                     p_param->p_hostinfo,
                     HTTP_SERVER_AUTH_TYPE_BEARER,
                     p_param->flag_access_from_lan,
-                    NULL));
+                    NULL,
+                    false));
         }
     }
     switch (p_param->p_auth_info->auth_type)

--- a/src/http_server_handle_req_get_auth.c
+++ b/src/http_server_handle_req_get_auth.c
@@ -255,6 +255,18 @@ http_server_handle_req_get_auth_deny(const wifiman_hostinfo_t* const p_hostinfo)
 }
 
 static http_server_resp_t
+http_server_handle_req_auth_bearer(const http_server_handle_req_auth_param_t* const p_param, const bool flag_allowed)
+{
+    const http_server_resp_auth_json_t* const p_auth_json = http_server_fill_auth_json(
+        p_param->p_hostinfo,
+        HTTP_SERVER_AUTH_TYPE_BEARER,
+        p_param->flag_access_from_lan,
+        NULL,
+        flag_allowed);
+    return flag_allowed ? http_server_resp_200_json(p_auth_json->buf) : http_server_resp_401_json(p_auth_json);
+}
+
+static http_server_resp_t
 http_server_handle_req_get_or_check_auth(
     const http_server_handle_req_auth_param_t* const p_param,
     const bool                                       flag_check,
@@ -274,21 +286,10 @@ http_server_handle_req_get_or_check_auth(
                 break;
             case HTTP_SERVER_AUTH_API_KEY_ALLOWED:
                 *p_flag_access_by_bearer_token = true;
-                return http_server_resp_200_json(http_server_fill_auth_json(
-                                                     p_param->p_hostinfo,
-                                                     HTTP_SERVER_AUTH_TYPE_BEARER,
-                                                     p_param->flag_access_from_lan,
-                                                     NULL,
-                                                     true)
-                                                     ->buf);
+                return http_server_handle_req_auth_bearer(p_param, true);
             case HTTP_SERVER_AUTH_API_KEY_PROHIBITED:
                 *p_flag_access_by_bearer_token = true;
-                return http_server_resp_401_json(http_server_fill_auth_json(
-                    p_param->p_hostinfo,
-                    HTTP_SERVER_AUTH_TYPE_BEARER,
-                    p_param->flag_access_from_lan,
-                    NULL,
-                    false));
+                return http_server_handle_req_auth_bearer(p_param, false);
         }
     }
     switch (p_param->p_auth_info->auth_type)

--- a/src/http_server_handle_req_get_auth.c
+++ b/src/http_server_handle_req_get_auth.c
@@ -255,14 +255,17 @@ http_server_handle_req_get_auth_deny(const wifiman_hostinfo_t* const p_hostinfo)
 }
 
 static http_server_resp_t
-http_server_handle_req_auth_bearer(const http_server_handle_req_auth_param_t* const p_param, const bool flag_allowed)
+http_server_handle_req_auth_bearer(
+    const http_server_handle_req_auth_param_t* const p_param,
+    const bool                                       flag_allowed,
+    const bool                                       flag_expose_ver_info)
 {
     const http_server_resp_auth_json_t* const p_auth_json = http_server_fill_auth_json(
         p_param->p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_BEARER,
         p_param->flag_access_from_lan,
         NULL,
-        flag_allowed);
+        flag_expose_ver_info);
     return flag_allowed ? http_server_resp_200_json(p_auth_json->buf) : http_server_resp_401_json(p_auth_json);
 }
 
@@ -286,10 +289,10 @@ http_server_handle_req_get_or_check_auth(
                 break;
             case HTTP_SERVER_AUTH_API_KEY_ALLOWED:
                 *p_flag_access_by_bearer_token = true;
-                return http_server_handle_req_auth_bearer(p_param, true);
+                return http_server_handle_req_auth_bearer(p_param, true, true);
             case HTTP_SERVER_AUTH_API_KEY_PROHIBITED:
                 *p_flag_access_by_bearer_token = true;
-                return http_server_handle_req_auth_bearer(p_param, false);
+                return http_server_handle_req_auth_bearer(p_param, false, false);
         }
     }
     switch (p_param->p_auth_info->auth_type)

--- a/src/http_server_handle_req_post_auth.c
+++ b/src/http_server_handle_req_post_auth.c
@@ -261,7 +261,8 @@ http_server_handle_req_post_auth(
             p_hostinfo,
             p_auth_info->auth_type,
             flag_access_from_lan,
-            NULL);
+            NULL,
+            true);
         return http_server_resp_200_json(p_auth_json->buf);
     }
     if ((HTTP_SERVER_AUTH_TYPE_RUUVI != p_auth_info->auth_type)
@@ -335,6 +336,7 @@ http_server_handle_req_post_auth(
         p_hostinfo,
         p_auth_info->auth_type,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }

--- a/src/http_server_resp.c
+++ b/src/http_server_resp.c
@@ -405,28 +405,38 @@ http_server_fill_auth_json(
     const char* const               p_err_message,
     const bool                      flag_expose_ver_info)
 {
-    str_buf_t str_buf = STR_BUF_INIT(g_auth_json.buf, sizeof(g_auth_json.buf));
-    str_buf_printf(&str_buf, "{\"gateway_name\": \"%s\"", p_hostinfo->hostname.buf);
-    if (flag_expose_ver_info)
+    str_buf_t str_buf      = STR_BUF_INIT(g_auth_json.buf, sizeof(g_auth_json.buf));
+    bool      flag_success = str_buf_printf(&str_buf, "{\"gateway_name\": \"%s\"", p_hostinfo->hostname.buf);
+    if (flag_success && flag_expose_ver_info)
     {
-        str_buf_printf(
+        flag_success = str_buf_printf(
             &str_buf,
             ", \"fw_ver\": \"%s\""
             ", \"nrf52_fw_ver\": \"%s\"",
             p_hostinfo->fw_ver.buf,
             p_hostinfo->nrf52_fw_ver.buf);
     }
-    str_buf_printf(
-        &str_buf,
-        ", \"lan_auth_type\": \"%s\""
-        ", \"lan\": %s",
-        http_server_auth_type_to_str(lan_auth_type),
-        flag_access_from_lan ? "true" : "false");
-    if (NULL != p_err_message)
+    if (flag_success)
     {
-        str_buf_printf(&str_buf, ", \"message\": \"%s\"", p_err_message);
+        flag_success = str_buf_printf(
+            &str_buf,
+            ", \"lan_auth_type\": \"%s\""
+            ", \"lan\": %s",
+            http_server_auth_type_to_str(lan_auth_type),
+            flag_access_from_lan ? "true" : "false");
     }
-    str_buf_printf(&str_buf, "}");
+    if (flag_success && (NULL != p_err_message))
+    {
+        flag_success = str_buf_printf(&str_buf, ", \"message\": \"%s\"", p_err_message);
+    }
+    if (flag_success)
+    {
+        flag_success = str_buf_printf(&str_buf, "}");
+    }
+    if (!flag_success)
+    {
+        memcpy(g_auth_json.buf, "{}", sizeof("{}"));
+    }
     return &g_auth_json;
 }
 

--- a/src/http_server_resp.c
+++ b/src/http_server_resp.c
@@ -402,55 +402,31 @@ http_server_fill_auth_json(
     const wifiman_hostinfo_t* const p_hostinfo,
     const http_server_auth_type_e   lan_auth_type,
     const bool                      flag_access_from_lan,
-    const char* const               p_err_message)
+    const char* const               p_err_message,
+    const bool                      flag_expose_ver_info)
 {
-    if (NULL == p_err_message)
+    str_buf_t str_buf = STR_BUF_INIT(g_auth_json.buf, sizeof(g_auth_json.buf));
+    str_buf_printf(&str_buf, "{\"gateway_name\": \"%s\"", p_hostinfo->hostname.buf);
+    if (flag_expose_ver_info)
     {
-        (void)snprintf(
-            g_auth_json.buf,
-            sizeof(g_auth_json.buf),
-            "{\"gateway_name\": \"%s\", "
-            "\"fw_ver\": \"%s\", "
-            "\"nrf52_fw_ver\": \"%s\", "
-            "\"lan_auth_type\": \"%s\", "
-            "\"lan\": %s}",
-            p_hostinfo->hostname.buf,
+        str_buf_printf(
+            &str_buf,
+            ", \"fw_ver\": \"%s\""
+            ", \"nrf52_fw_ver\": \"%s\"",
             p_hostinfo->fw_ver.buf,
-            p_hostinfo->nrf52_fw_ver.buf,
-            http_server_auth_type_to_str(lan_auth_type),
-            flag_access_from_lan ? "true" : "false");
+            p_hostinfo->nrf52_fw_ver.buf);
     }
-    else
+    str_buf_printf(
+        &str_buf,
+        ", \"lan_auth_type\": \"%s\""
+        ", \"lan\": %s",
+        http_server_auth_type_to_str(lan_auth_type),
+        flag_access_from_lan ? "true" : "false");
+    if (NULL != p_err_message)
     {
-        (void)snprintf(
-            g_auth_json.buf,
-            sizeof(g_auth_json.buf),
-            "{\"gateway_name\": \"%s\", "
-            "\"fw_ver\": \"%s\", "
-            "\"nrf52_fw_ver\": \"%s\", "
-            "\"lan_auth_type\": \"%s\", "
-            "\"lan\": %s, "
-            "\"message\": \"%s\"}",
-            p_hostinfo->hostname.buf,
-            p_hostinfo->fw_ver.buf,
-            p_hostinfo->nrf52_fw_ver.buf,
-            http_server_auth_type_to_str(lan_auth_type),
-            flag_access_from_lan ? "true" : "false",
-            p_err_message);
+        str_buf_printf(&str_buf, ", \"message\": \"%s\"", p_err_message);
     }
-    return &g_auth_json;
-}
-
-const http_server_resp_auth_json_t*
-http_server_fill_auth_json_bearer(const wifiman_hostinfo_t* const p_hostinfo)
-{
-    (void)snprintf(
-        g_auth_json.buf,
-        sizeof(g_auth_json.buf),
-        "{\"gateway_name\": \"%s\", \"fw_ver\": \"%s\", \"nrf52_fw_ver\": \"%s\"}",
-        p_hostinfo->hostname.buf,
-        p_hostinfo->fw_ver.buf,
-        p_hostinfo->nrf52_fw_ver.buf);
+    str_buf_printf(&str_buf, "}");
     return &g_auth_json;
 }
 
@@ -479,7 +455,8 @@ http_server_resp_401_auth_digest(
         p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_DIGEST,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        false);
     (void)snprintf(
         p_extra_header_fields->buf,
         sizeof(p_extra_header_fields->buf),
@@ -536,7 +513,8 @@ http_server_resp_401_auth_ruuvi_with_new_session_id(
         p_hostinfo,
         lan_auth_type,
         flag_access_from_lan,
-        p_err_message);
+        p_err_message,
+        false);
     return http_server_resp_401_json(p_auth_json);
 }
 
@@ -549,7 +527,8 @@ http_server_resp_401_auth_ruuvi(const wifiman_hostinfo_t* const p_hostinfo, cons
         p_hostinfo,
         lan_auth_type,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        false);
     return http_server_resp_401_json(p_auth_json);
 }
 
@@ -582,7 +561,8 @@ http_server_resp_200_auth_allow_with_new_session_id(
         p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_ALLOW,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        true);
     return http_server_resp_200_json(p_auth_json->buf);
 }
 
@@ -595,7 +575,8 @@ http_server_resp_403_auth_deny(const wifiman_hostinfo_t* const p_hostinfo)
         p_hostinfo,
         HTTP_SERVER_AUTH_TYPE_DENY,
         flag_access_from_lan,
-        NULL);
+        NULL,
+        false);
     return http_server_resp_403_json(p_auth_json);
 }
 

--- a/src/http_server_resp.c
+++ b/src/http_server_resp.c
@@ -13,6 +13,7 @@
 #include "http_server_auth.h"
 #include "json_stream_gen.h"
 #include "os_malloc.h"
+#include "str_buf.h"
 #define LOG_LOCAL_LEVEL LOG_LEVEL_INFO
 #include "log.h"
 

--- a/src/include/http_server_resp.h
+++ b/src/include/http_server_resp.h
@@ -166,7 +166,7 @@ http_server_resp_403_forbidden(void);
  * authentication type, and LAN access status.
  *
  * @note The firmware version information should not be exposed to unauthenticated users.
- *       Therefore, the `flag_add_ver_info` parameter should be set to `false`.
+ *       Therefore, the `flag_expose_ver_info` parameter should be set to `false`.
  *
  * @param[in] p_hostinfo Pointer to the host information structure. Must not be NULL.
  * @param[in] lan_auth_type The LAN authentication type as an enumerated value of type http_server_auth_type_e.

--- a/src/include/http_server_resp.h
+++ b/src/include/http_server_resp.h
@@ -157,15 +157,37 @@ http_server_resp_403_auth_deny(const wifiman_hostinfo_t* const p_hostinfo);
 http_server_resp_t
 http_server_resp_403_forbidden(void);
 
+/**
+ * @brief Generate an authentication JSON object for HTTP server responses.
+ *
+ * This function populates a JSON object containing authentication-related details
+ * for the HTTP server response based on the provided parameters. The JSON format
+ * can include various fields such as the gateway name, firmware versions, LAN
+ * authentication type, and LAN access status.
+ *
+ * @note The firmware version information should not be exposed to unauthenticated users.
+ *       Therefore, the `flag_add_ver_info` parameter should be set to `false`.
+ *
+ * @param[in] p_hostinfo Pointer to the host information structure. Must not be NULL.
+ * @param[in] lan_auth_type The LAN authentication type as an enumerated value of type http_server_auth_type_e.
+ * @param[in] flag_access_from_lan Boolean flag indicating if access is from LAN.
+ * @param[in] p_err_message Optional error message string. Can be NULL if no error message is needed.
+ * @param[in] flag_expose_ver_info Boolean flag indicating whether to include version
+ *                                 information in the JSON output.
+ *                                 It should be set to false for unauthenticated users to avoid exposing
+ *                                 firmware version details.
+ *
+ * @return A pointer to the generated authentication JSON object.
+ *         The JSON object is stored in a statically allocated buffer, so the pointer
+ *         remains valid until the next call to this function.
+ */
 const http_server_resp_auth_json_t*
 http_server_fill_auth_json(
     const wifiman_hostinfo_t* const p_hostinfo,
     const http_server_auth_type_e   lan_auth_type,
     const bool                      flag_access_from_lan,
-    const char* const               p_err_message);
-
-const http_server_resp_auth_json_t*
-http_server_fill_auth_json_bearer(const wifiman_hostinfo_t* const p_hostinfo);
+    const char* const               p_err_message,
+    const bool                      flag_expose_ver_info);
 
 void
 http_server_resp_free(http_server_resp_t* const p_resp);

--- a/tests/test_http_server_handle_req_get_auth/test_http_server_handle_req_get_auth.cpp
+++ b/tests/test_http_server_handle_req_get_auth/test_http_server_handle_req_get_auth.cpp
@@ -425,7 +425,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_deny) // NOLINT
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_deny", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_deny", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_403, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -530,7 +530,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_basic_fail_no_header_authorizat
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_basic", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_basic", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -585,7 +585,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_basic_fail_wrong_header_authori
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_basic", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_basic", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -640,7 +640,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_basic_fail_short_password) // N
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_basic", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_basic", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -695,7 +695,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_basic_fail_incorrect_password) 
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_basic", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_basic", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -808,7 +808,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_digest_fail_no_header_authoriza
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_digest", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_digest", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -866,7 +866,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_digest_fail_wrong_header_author
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_digest", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_digest", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -925,7 +925,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_digest_fail_wrong_password) // 
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_digest", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_digest", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -984,7 +984,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_digest_fail_wrong_user) // NOLI
     };
     const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
     const string             exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_digest", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_digest", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -1043,7 +1043,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_success) // NOLINT
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1173,7 +1173,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_success) // NOLINT
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1234,7 +1234,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_password) // N
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1283,7 +1283,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_password) // N
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1344,7 +1344,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_user) // NOLIN
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1393,7 +1393,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_user) // NOLIN
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1454,7 +1454,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_empty_user) // NOLIN
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1503,7 +1503,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_empty_user) // NOLIN
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1564,7 +1564,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_realm) // NOLI
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1613,7 +1613,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_realm) // NOLI
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1674,7 +1674,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_remote_ip) // 
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1723,7 +1723,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_remote_ip) // 
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1784,7 +1784,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_session_id) //
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1833,7 +1833,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_wrong_session_id) //
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1894,7 +1894,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_empty_session_id) //
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -1943,7 +1943,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_empty_session_id) //
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2004,7 +2004,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_no_session_id) // NO
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2052,7 +2052,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_no_session_id) // NO
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2113,7 +2113,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_missing_quo
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2162,7 +2162,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_missing_quo
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2223,7 +2223,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_no_username
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2271,7 +2271,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_no_username
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2332,7 +2332,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_no_password
         };
         const http_server_resp_t resp = http_server_handle_req_get_auth(&param, &extra_header_fields);
         const string             exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2369,7 +2369,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_ruuvi_fail_bad_body_no_password
             &hostinfo,
             &extra_header_fields);
         const string exp_json_resp
-            = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+            = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
         ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
         ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
         ASSERT_TRUE(resp.flag_no_cache);
@@ -2647,7 +2647,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_non_empty_ro_access_to_r
         &extra_header_fields,
         &flag_access_by_bearer_token);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_bearer", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_bearer", "lan": true})";
     ASSERT_EQ(HTTP_RESP_CODE_401, resp.http_resp_code);
     ASSERT_EQ(HTTP_CONTENT_LOCATION_STATIC_MEM, resp.content_location);
     ASSERT_TRUE(resp.flag_no_cache);
@@ -2721,7 +2721,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_non_empty_failed_differe
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_bearer", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_bearer", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));
@@ -2785,7 +2785,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_non_empty_failed_wrong_a
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_bearer", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_bearer", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));
@@ -2848,7 +2848,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_empty_1) // NOLINT
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_bearer", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_bearer", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));
@@ -2910,7 +2910,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_empty_2) // NOLINT
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_bearer", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_bearer", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));
@@ -2971,7 +2971,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_no_auth_not_used) // NOL
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));
@@ -3033,7 +3033,7 @@ TEST_F(TestHttpServerHandleReqGetAuth, test_auth_bearer_wrong_auth_not_used) // 
     ASSERT_EQ(nullptr, resp.p_content_type_param);
     ASSERT_EQ(HTTP_CONTENT_ENCODING_NONE, resp.content_encoding);
     const string exp_json_resp
-        = R"({"gateway_name": "RuuviGatewayEEFF", "fw_ver": "1.13.0", "nrf52_fw_ver": "1.0.0", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
+        = R"({"gateway_name": "RuuviGatewayEEFF", "lan_auth_type": "lan_auth_ruuvi", "lan": true})";
     ASSERT_EQ(exp_json_resp, string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_EQ(exp_json_resp.length(), resp.content_len);
     ASSERT_EQ(string(""), string(extra_header_fields.buf));

--- a/tests/test_http_server_resp/test_http_server_resp.cpp
+++ b/tests/test_http_server_resp/test_http_server_resp.cpp
@@ -983,8 +983,7 @@ TEST_F(TestHttpServerResp, resp_401_auth_ruuvi) // NOLINT
     ASSERT_TRUE(resp.flag_add_header_date);
     ASSERT_EQ(HTTP_CONTENT_TYPE_APPLICATION_JSON, resp.content_type);
     ASSERT_EQ(
-        "{\"gateway_name\": \"hostname\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\", \"lan_auth_type\": "
-        "\"lan_auth_ruuvi\", \"lan\": true}",
+        "{\"gateway_name\": \"hostname\", \"lan_auth_type\": \"lan_auth_ruuvi\", \"lan\": true}",
         string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     http_server_resp_free(&resp);
     ASSERT_EQ(0, this->m_alloc_free_call_count);
@@ -1013,10 +1012,10 @@ TEST_F(TestHttpServerResp, resp_401_auth_ruuvi_with_new_session_id_with_err_mess
     ASSERT_TRUE(resp.flag_no_cache);
     ASSERT_TRUE(resp.flag_add_header_date);
     ASSERT_EQ(HTTP_CONTENT_TYPE_APPLICATION_JSON, resp.content_type);
-    ASSERT_NE(
-        string::npos,
-        string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf))
-            .find("\"message\": \"wrong password\""));
+    ASSERT_EQ(
+        "{\"gateway_name\": \"hostname\", \"lan_auth_type\": \"lan_auth_ruuvi\", \"lan\": true, "
+        "\"message\": \"wrong password\"}",
+        string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_NE(
         string::npos,
         string(extra_header_fields.buf).find("WWW-Authenticate: x-ruuvi-interactive realm=\"hostname\""));
@@ -1066,6 +1065,9 @@ TEST_F(TestHttpServerResp, resp_401_auth_digest) // NOLINT
     ASSERT_TRUE(resp.flag_no_cache);
     ASSERT_TRUE(resp.flag_add_header_date);
     ASSERT_EQ(HTTP_CONTENT_TYPE_APPLICATION_JSON, resp.content_type);
+    ASSERT_EQ(
+        "{\"gateway_name\": \"hostname\", \"lan_auth_type\": \"lan_auth_digest\", \"lan\": true}",
+        string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     ASSERT_NE(
         string::npos,
         string(extra_header_fields.buf).find("WWW-Authenticate: Digest realm=\"hostname\" qop=\"auth\" nonce=\""));
@@ -1106,8 +1108,7 @@ TEST_F(TestHttpServerResp, resp_403_auth_deny) // NOLINT
     ASSERT_TRUE(resp.flag_add_header_date);
     ASSERT_EQ(HTTP_CONTENT_TYPE_APPLICATION_JSON, resp.content_type);
     ASSERT_EQ(
-        "{\"gateway_name\": \"hostname\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\", \"lan_auth_type\": "
-        "\"lan_auth_deny\", \"lan\": true}",
+        "{\"gateway_name\": \"hostname\", \"lan_auth_type\": \"lan_auth_deny\", \"lan\": true}",
         string(reinterpret_cast<const char*>(resp.select_location.static_mem.p_buf)));
     http_server_resp_free(&resp);
     ASSERT_EQ(0, this->m_alloc_free_call_count);
@@ -1126,20 +1127,6 @@ TEST_F(TestHttpServerResp, resp_403_forbidden) // NOLINT
     ASSERT_EQ(0, this->m_alloc_free_call_count);
 }
 
-TEST_F(TestHttpServerResp, fill_auth_json_bearer) // NOLINT
-{
-    const wifiman_hostinfo_t hostinfo = { .hostname     = { "hostname" },
-                                          .fw_ver       = { "v1.15.0" },
-                                          .nrf52_fw_ver = { "v1.0.0" } };
-
-    const http_server_resp_auth_json_t* const p_auth_json = http_server_fill_auth_json_bearer(&hostinfo);
-    ASSERT_NE(nullptr, p_auth_json);
-    ASSERT_EQ(
-        "{\"gateway_name\": \"hostname\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\"}",
-        string(p_auth_json->buf));
-    ASSERT_EQ(0, this->m_alloc_free_call_count);
-}
-
 TEST_F(TestHttpServerResp, fill_auth_json_without_err_message_lan_true) // NOLINT
 {
     const wifiman_hostinfo_t hostinfo = { .hostname     = { "mygw" },
@@ -1150,7 +1137,8 @@ TEST_F(TestHttpServerResp, fill_auth_json_without_err_message_lan_true) // NOLIN
         &hostinfo,
         HTTP_SERVER_AUTH_TYPE_RUUVI,
         true,
-        NULL);
+        NULL,
+        true);
     ASSERT_NE(nullptr, p_auth_json);
     ASSERT_EQ(
         "{\"gateway_name\": \"mygw\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\", "
@@ -1169,7 +1157,8 @@ TEST_F(TestHttpServerResp, fill_auth_json_without_err_message_lan_false) // NOLI
         &hostinfo,
         HTTP_SERVER_AUTH_TYPE_DENY,
         false,
-        NULL);
+        NULL,
+        true);
     ASSERT_NE(nullptr, p_auth_json);
     ASSERT_EQ(
         "{\"gateway_name\": \"mygw\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\", "
@@ -1188,7 +1177,8 @@ TEST_F(TestHttpServerResp, fill_auth_json_with_err_message) // NOLINT
         &hostinfo,
         HTTP_SERVER_AUTH_TYPE_RUUVI,
         true,
-        "wrong password");
+        "wrong password",
+        true);
     ASSERT_NE(nullptr, p_auth_json);
     ASSERT_EQ(
         "{\"gateway_name\": \"mygw\", \"fw_ver\": \"v1.15.0\", \"nrf52_fw_ver\": \"v1.0.0\", "
@@ -1205,7 +1195,8 @@ TEST_F(TestHttpServerResp, fill_auth_json_auth_type_allow) // NOLINT
         &hostinfo,
         HTTP_SERVER_AUTH_TYPE_ALLOW,
         true,
-        NULL);
+        NULL,
+        true);
     ASSERT_NE(nullptr, p_auth_json);
     ASSERT_EQ(
         "{\"gateway_name\": \"gw1\", \"fw_ver\": \"v2.0.0\", \"nrf52_fw_ver\": \"v1.1.0\", "
@@ -1222,11 +1213,32 @@ TEST_F(TestHttpServerResp, fill_auth_json_auth_type_digest) // NOLINT
         &hostinfo,
         HTTP_SERVER_AUTH_TYPE_DIGEST,
         true,
-        NULL);
+        NULL,
+        true);
     ASSERT_NE(nullptr, p_auth_json);
     ASSERT_EQ(
         "{\"gateway_name\": \"gw1\", \"fw_ver\": \"v2.0.0\", \"nrf52_fw_ver\": \"v1.1.0\", "
         "\"lan_auth_type\": \"lan_auth_digest\", \"lan\": true}",
+        string(p_auth_json->buf));
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}
+
+TEST_F(TestHttpServerResp, fill_auth_json_without_version_info) // NOLINT
+{
+    const wifiman_hostinfo_t hostinfo = { .hostname     = { "mygw" },
+                                          .fw_ver       = { "v1.15.0" },
+                                          .nrf52_fw_ver = { "v1.0.0" } };
+
+    const http_server_resp_auth_json_t* const p_auth_json = http_server_fill_auth_json(
+        &hostinfo,
+        HTTP_SERVER_AUTH_TYPE_RUUVI,
+        true,
+        "wrong password",
+        false);
+    ASSERT_NE(nullptr, p_auth_json);
+    ASSERT_EQ(
+        "{\"gateway_name\": \"mygw\", \"lan_auth_type\": \"lan_auth_ruuvi\", \"lan\": true, "
+        "\"message\": \"wrong password\"}",
         string(p_auth_json->buf));
     ASSERT_EQ(0, this->m_alloc_free_call_count);
 }

--- a/tests/test_http_server_resp/test_http_server_resp.cpp
+++ b/tests/test_http_server_resp/test_http_server_resp.cpp
@@ -1242,3 +1242,21 @@ TEST_F(TestHttpServerResp, fill_auth_json_without_version_info) // NOLINT
         string(p_auth_json->buf));
     ASSERT_EQ(0, this->m_alloc_free_call_count);
 }
+
+TEST_F(TestHttpServerResp, fill_auth_json_overflow_returns_valid_minimal_json) // NOLINT
+{
+    const wifiman_hostinfo_t hostinfo = { .hostname     = { "mygw" },
+                                          .fw_ver       = { "v1.15.0" },
+                                          .nrf52_fw_ver = { "v1.0.0" } };
+    const string             err_message(HTTP_SERVER_RESP_JSON_AUTH_BUF_SIZE, 'x');
+
+    const http_server_resp_auth_json_t* const p_auth_json = http_server_fill_auth_json(
+        &hostinfo,
+        HTTP_SERVER_AUTH_TYPE_RUUVI,
+        true,
+        err_message.c_str(),
+        true);
+    ASSERT_NE(nullptr, p_auth_json);
+    ASSERT_EQ("{}", string(p_auth_json->buf));
+    ASSERT_EQ(0, this->m_alloc_free_call_count);
+}


### PR DESCRIPTION
Close #337
Add explicit control over including gateway and nRF52 firmware versions in authentication JSON responses. Omit both versions from unsuccessful authentication and authorization responses while preserving them for authenticated clients.